### PR TITLE
Update outdated links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before you can contribute it is important to know what area you would like to co
 
 ### Prerequisites for PRUDP
 
-PRUDP(S) is the protocol layer ontop of all network requests made by the Nintendo WiiU/3DS family of consoles. It is a simple protocol spec sitting on top of UDP. It aims to make UDP reliable and secure, and was originally developed by [Quazal](http://www.quazal.com/index.html), with a custom version made for Nintendo.
+PRUDP(S) is the protocol layer ontop of all network requests made by the Nintendo WiiU/3DS family of consoles. It is a simple protocol spec sitting on top of UDP. It aims to make UDP reliable and secure, and was originally developed by [Quazal](https://en.wikipedia.org/wiki/List_of_Ubisoft_subsidiaries#Quazal), with a custom version made for Nintendo.
 
 For more information about PRUDP, see [this Wiki](https://github.com/Kinnay/NintendoClients/wiki/PRUDP-Protocol)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pretendo is a large project with many smaller sections, each with their own goal
 - eShop (PoC) [https://github.com/PretendoNetwork/eShop](https://github.com/PretendoNetwork/eShop)
 
 # Non-service repositories:
-- Official Discord bot [https://github.com/PretendoNetwork/Yamamura](https://github.com/PretendoNetwork/Yamamura)
+- Official Discord bot [https://github.com/PretendoNetwork/Bandwidth](https://github.com/PretendoNetwork/Bandwidth)
 - Official proxy [https://github.com/PretendoNetwork/maryo](https://github.com/PretendoNetwork/maryo)
 
 ## License
@@ -27,7 +27,7 @@ This project is licensed under the Mozilla Public License 2.0 License - see the 
 
 ## Acknowledgments
 
-* PRUDP/NEX was originally designed and developed by [Quazal](http://www.quazal.com/index.html)
+* PRUDP/NEX was originally designed and developed by [Quazal](https://en.wikipedia.org/wiki/List_of_Ubisoft_subsidiaries#Quazal)
 * Huge thanks to [Kinnay](https://github.com/Kinnay) as without his reverse engineering work and documentation of PRUDP and NEX, we doubt Pretendo would be anywhere today.
 
 Our full list of acknowledgements are visible on [our website](https://pretendo.network/#credits)


### PR DESCRIPTION
Hi, I noticed some outdated information in this repo's files and thought they should be changed. Since the repo's issues are mostly non-developers looking for tech support, I opted to create a pull request instead to start a more serious discussion.

Currently, the changes are:
- Changed the Discord bot repo link to Bandwidth (instead of Yamamura)
- Changed the links to Quazal to a Wikipedia article as I didn't find a better website (this could close #11)

Let me know if there are any more appropriate changes to be made, I'll add them in.